### PR TITLE
Fix sync update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM abernix/spaceglue:node-8-onbuild
+FROM aedm/minimeteor

--- a/imports/ui/components/Sync/SyncUpdates.jsx
+++ b/imports/ui/components/Sync/SyncUpdates.jsx
@@ -4,6 +4,7 @@ import { Meteor } from 'meteor/meteor';
 import { withTracker } from 'meteor/react-meteor-data';
 import PropTypes from 'prop-types';
 import axios from 'axios';
+import M from 'materialize-css';
 import { _ } from 'lodash';
 import { Resources, References } from '../../../api/resources/resources';
 import { _SearchData } from '../../../api/search/search';
@@ -63,17 +64,18 @@ export class SyncUpdates extends Component {
         course.details,
         err => {
           err
-            ? (Materialize.toast(err.reason, 3000, 'error-toast'),
+            ? (M.toast({
+              html: `<span>${err.reason}</span>`,
+              classes: 'red',
+            }),
             Meteor.call(
               'logger',
               formatText(err.message, Meteor.userId(), 'course'),
               'error',
             ))
-            : Materialize.toast(
-              `Successfully synced ${coursesSync.length} `,
-              3000,
-              'success-toast',
-            );
+            : M.toast({
+              html: `<span>Successfully synced ${coursesSync.length}</span>`,
+            });
         },
       );
     });
@@ -91,17 +93,18 @@ export class SyncUpdates extends Component {
         unit.details,
         err => {
           err
-            ? (Materialize.toast(err.reason, 3000, 'error-toast'),
+            ? (M.toast({
+              html: `<span>${err.reason}</span>`,
+              classes: 'red',
+            }),
             Meteor.call(
               'logger',
               formatText(err.message, Meteor.userId(), 'units'),
               'error',
             ))
-            : Materialize.toast(
-              `Successfully synced ${unitsData.length} `,
-              3000,
-              'success-toast',
-            );
+            : M.toast({
+              html: `<span>Successfully synced ${unitsData.length}</span>`,
+            });
         },
       );
     });
@@ -117,17 +120,18 @@ export class SyncUpdates extends Component {
         topic.unit,
         err => {
           err
-            ? (Materialize.toast(err.reason, 3000, 'error-toast'),
+            ? (M.toast({
+              html: `<span>${err.reason}</span>`,
+              classes: 'red',
+            }),
             Meteor.call(
               'logger',
               formatText(err.message, Meteor.userId(), 'topics'),
               'error',
             ))
-            : Materialize.toast(
-              `Successfully synced ${topicsData.length} `,
-              3000,
-              'success-toast',
-            );
+            : M.toast({
+              html: `<span>Successfully synced ${topicsData.length}</span>`,
+            });
         },
       );
     });

--- a/imports/ui/components/Sync/SyncUpdates.jsx
+++ b/imports/ui/components/Sync/SyncUpdates.jsx
@@ -378,7 +378,7 @@ const InputPassword = props => (
       <div className="input-field col s12 m6">
         <input
           id="inst_tag"
-          type="text"
+          type="password"
           className="validate"
           required
           style={{ color: props.isDark ? '#F5FAF8' : '#000000' }}


### PR DESCRIPTION
- Sync updates still had the the old toast

`Materialize.toast(...)`, I have replaced this with a newer version which takes in an html node, like so
`M.toast({html: <node>, classes: ' '})`

- The password was also showing when typing in the field but this has been updated